### PR TITLE
 Symphony: bill creation date never returned

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
@@ -1354,8 +1354,8 @@ class Symphony extends AbstractBase
                         'fine' => $fee->billReasonDescription,
                         'balance' => $fee->amountOutstanding->_ * 100,
                         'createdate' =>
-                            isset($fee->feeItemInfo->dateBilled) ?
-                            $fee->feeItemInfo->dateBilled : null,
+                            isset($fee->dateBilled) ? 
+                            $fee->dateBilled : null,
                         'duedate' =>
                             isset($fee->feeItemInfo->dueDate) ?
                             $fee->feeItemInfo->dueDate : null,


### PR DESCRIPTION
The bill creation date is returned in the top level FeeInfo object returned
by Web Services, unlike the Checkout and Due Dates, which are returned
in the FeeItem child object, which described the item (book, etc.)
on which the fee was incurred (if appropriate). The code assumed
that all dates would be in the FeeItem object.